### PR TITLE
update to latest clojure and core.async

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,11 +5,12 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/core.async "0.7.559"]
                  [fullcontact/camelsnake "0.9.0"]
                  [fullcontact/full.async "0.9.0"]
                  [fullcontact/full.core "0.10.1" :exclusions [org.clojure/clojurescript]]
-                 [fullcontact/full.http "0.10.8"]]
+                 [fullcontact/full.http "1.0.6"]]
   :aot :all
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]


### PR DESCRIPTION
@gazz - this should fix the core.async dependency problems for when clojure 1.10 projects are including this. Can you please review and help me with the release process?